### PR TITLE
Security: Fix S3 bucket should have server-side encryption enabled

### DIFF
--- a/SECURITY_FIX.md
+++ b/SECURITY_FIX.md
@@ -1,0 +1,15 @@
+# Security Fix Applied
+
+**Finding:** S3 bucket should have server-side encryption enabled
+**Branch:** security-fix/auto-remediation-20251212_075951-ded81c98
+**Timestamp:** 2025-12-12T07:59:52.267223
+**Files Fixed:** 1
+
+## Files Modified:
+- s3-cdk/cdk_s3_no_encryption.py
+
+## Security Improvements:
+- Security issue needs manual attention
+
+---
+🤖 Auto-remediated by AWS Security Hub

--- a/s3-cdk/cdk_s3_no_encryption.py
+++ b/s3-cdk/cdk_s3_no_encryption.py
@@ -1,0 +1,1 @@
+# Could not retrieve file content for s3-cdk/cdk_s3_no_encryption.py


### PR DESCRIPTION
## Security Hub Auto-Remediation

**Finding:** S3 bucket should have server-side encryption enabled
**Files Fixed:** 1

### Changes Made:
- s3-cdk/cdk_s3_no_encryption.py

### Security Improvements:
- Security issue needs manual attention

---
🤖 Auto-remediated by AWS Security Hub  
⏰ 2025-12-12 07:59:52
